### PR TITLE
Bump auth-service to v0.0.6

### DIFF
--- a/yggdrasil/applications/eo/eo-auth-service.yaml
+++ b/yggdrasil/applications/eo/eo-auth-service.yaml
@@ -2,10 +2,10 @@ eo-base-helm-chart:
   deployments:
     api:
       image:
-        tag: v0.0.5
+        tag: v0.0.6
     consumer:
       image:
-        tag: v0.0.5
+        tag: v0.0.6
   env:
     DEBUG: 1
     EVENT_BUS_HOST: dev-cluster-kafka-bootstrap.eo-kafka.svc.cluster.local


### PR DESCRIPTION
Bump auth-service to v0.0.6

- Triggered by [Job][1] in [Repo][2]

[1]: https://github.com/Energinet-DataHub/eo-auth/actions/runs/1481076089 
[2]: https://github.com/Energinet-DataHub/eo-auth