### PR TITLE
Bump auth-service to v0.0.7

### DIFF
--- a/yggdrasil/applications/eo/eo-auth-service.yaml
+++ b/yggdrasil/applications/eo/eo-auth-service.yaml
@@ -2,7 +2,7 @@ eo-base-helm-chart:
   deployments:
     api:
       image:
-        tag: v0.0.6
+        tag: v0.0.7
   env:
     DEBUG: 1
     EVENT_BUS_HOST: dev-cluster-kafka-bootstrap.eo-kafka.svc.cluster.local


### PR DESCRIPTION
Bump auth-service to v0.0.7

- Triggered by [Job][1] in [Repo][2]

[1]: https://github.com/Energinet-DataHub/eo-auth/actions/runs/1481131795 
[2]: https://github.com/Energinet-DataHub/eo-auth