### PR TITLE
Bump auth-service to v0.0.8

### DIFF
--- a/yggdrasil/applications/eo/eo-auth-service.yaml
+++ b/yggdrasil/applications/eo/eo-auth-service.yaml
@@ -2,7 +2,7 @@ eo-base-helm-chart:
   deployments:
     api:
       image:
-        tag: v0.0.7
+        tag: v0.0.8
   env:
     DEBUG: 1
     EVENT_BUS_HOST: dev-cluster-kafka-bootstrap.eo-kafka.svc.cluster.local
@@ -11,7 +11,7 @@ eo-base-helm-chart:
     SQL_URI: postgresql://postgres:1234@eo-postgresql.eo-postgresql.svc.cluster.local:5432/auth
   ingress:
     hosts:
-      - '{{ .Values.ingressDomain }}'
-    httpMiddelwares: 
-      - https-only
+    - '{{ .Values.ingressDomain }}'
+    httpMiddelwares:
+    - https-only
     tlsSecretName: elop-cert


### PR DESCRIPTION
Bump auth-service to v0.0.8

- Triggered by [Job][1] in [Repo][2]

[1]: https://github.com/Energinet-DataHub/eo-auth/actions/runs/1490369274 
[2]: https://github.com/Energinet-DataHub/eo-auth