### PR TITLE
feat(development): make auth cookie client-side

### DIFF
--- a/env/development/nidhogg.yaml
+++ b/env/development/nidhogg.yaml
@@ -9,15 +9,13 @@ nidhogg:
 
     ingress:
       cors:
-        - "https://localdev.energioprindelse.dk:4200"
-        - "https://local.dev.energioprindelse.dk:4200"
-        - "https://localhost:4200"
         - "http://localhost:4200"
 
     eo:
       auth:
         env:
           OIDC_AUTHORITY_URL: "https://pp.netseidbroker.dk/op"
+          TOKEN_COOKIE_HTTP_ONLY: "False"
           TOKEN_COOKIE_SAMESITE: "False"
         envSecrets:
           OIDC_CLIENT_ID:

--- a/env/temp_dev/nidhogg.yaml
+++ b/env/temp_dev/nidhogg.yaml
@@ -15,8 +15,9 @@ nidhogg:
       auth:
         env:
           OIDC_AUTHORITY_URL: "https://pp.netseidbroker.dk/op"
+          TOKEN_COOKIE_HTTP_ONLY: "False"
           TOKEN_COOKIE_SAMESITE: "False"
-          TOKEN_COOKIE_SECURE: "False"
+          # TOKEN_COOKIE_SECURE: "False"
         envSecrets:
           OIDC_CLIENT_ID:
             secretName: eo-oidc-secret

--- a/env/temp_dev/nidhogg.yaml
+++ b/env/temp_dev/nidhogg.yaml
@@ -16,6 +16,7 @@ nidhogg:
         env:
           OIDC_AUTHORITY_URL: 'https://pp.netseidbroker.dk/op'
           TOKEN_COOKIE_SAMESITE: 'False'
+          TOKEN_COOKIE_SECURE: 'False'
         envSecrets:
           OIDC_CLIENT_ID:
             secretName: eo-oidc-secret

--- a/env/temp_dev/nidhogg.yaml
+++ b/env/temp_dev/nidhogg.yaml
@@ -17,7 +17,6 @@ nidhogg:
           OIDC_AUTHORITY_URL: "https://pp.netseidbroker.dk/op"
           TOKEN_COOKIE_HTTP_ONLY: "False"
           TOKEN_COOKIE_SAMESITE: "False"
-          # TOKEN_COOKIE_SECURE: "False"
         envSecrets:
           OIDC_CLIENT_ID:
             secretName: eo-oidc-secret

--- a/env/temp_dev/nidhogg.yaml
+++ b/env/temp_dev/nidhogg.yaml
@@ -14,9 +14,9 @@ nidhogg:
     eo:
       auth:
         env:
-          OIDC_AUTHORITY_URL: 'https://pp.netseidbroker.dk/op'
-          TOKEN_COOKIE_SAMESITE: 'False'
-          TOKEN_COOKIE_SECURE: 'False'
+          OIDC_AUTHORITY_URL: "https://pp.netseidbroker.dk/op"
+          TOKEN_COOKIE_SAMESITE: "False"
+          TOKEN_COOKIE_SECURE: "False"
         envSecrets:
           OIDC_CLIENT_ID:
             secretName: eo-oidc-secret
@@ -31,8 +31,8 @@ nidhogg:
               oidc_client_secret: "AgCuexYnwUDL+E8VyDelez+Yy6j5qDNHEPNxHlgupe5BYqxGMTIDzG/vq9XNrcxVmxD6p7lUn91dOwX+03D2mT1i02/rwbSmN55fiGpjCsbkyx1RDOFoJgQo6va2GDBHhNsAa2SkcxBlf8R+LoYXMeGw89MKr78XQkqLUMPUZoAv2FWzo6uHv2u2HylCrMxU79y74RTgy5NeNwoawiC7DvDL7khaUHj1E2bj9ydXCPhwdHrlWguVWyDcbyFV1v+QbHcnnvqw9T7MBTeEZsozEDMKTxC8sbhCyTF/9X9z6nqnak4ebpBF0Kne6WaiqXZ2MSYARQfBst3723bUTMcIby3hp7eLpOKaNwlyd3ny2bhABzFhknVw6Q9UIUee8R/0xAWqgn7ILT7VParcyrQg2qLw0ghYeNA+wvY5sN/Pv8dBcrOXPCG3RpmFsBNKBiwSWJQMWVxjYTS+SRWdBc0ahOln47WeVvwEzHszWHOFIOCmdDqdDksTdSM1yUqr1ItUIsqt1PzZJxFK9anYeSqazM/VCzzaPogMc5jmo36snikj1Z1rwE0G39tbZLZIQFKGgB3q2xASrks3MivwKCGkMqYigaT36WlZ+W1Wy6J9oQbB0HC9zNPUOAmwBsIBroTnUtl1TovQI+qmtu12zSEjqTlrMIIVAritI2sEtwrxchKy5RtHWJz8n3ztBChHx9kE2+zjuYgw5HBlw3etLbHZ8Fjpkk5x7MWqmlxR1ANZ26h5Dxir6k2gzgspXRL8NmfXjwdULeuDQ6EolL3vlEVde7WJlM3mVuY47NwLULq8J+plw4pxWJa7Qin+"
 
   argo-cd-proxy-chart:
-    argo-cd: 
-      server: 
+    argo-cd:
+      server:
         extraArgs:
           - --insecure
           - --rootpath


### PR DESCRIPTION
- Remove `HttpOnly` from `Authorization` cookie in Development environments to enable local frontend development